### PR TITLE
Bugfix/login import

### DIFF
--- a/client/version_control/api/models.py
+++ b/client/version_control/api/models.py
@@ -239,7 +239,7 @@ class ServerWorkspaces:
         return WorkspaceInfo(**settings)
 
     def get_host_workspaces(
-        self, host: str, primary: bool = False
+        self, host: typing.Union[str, None] = None, primary: bool = False
     ) -> typing.List[WorkspaceInfo]:
         """
         Retrieves workspaces associated with a specific host and primary status.
@@ -252,6 +252,9 @@ class ServerWorkspaces:
         Returns:
             List[WorkspaceInfo]: A list of WorkspaceInfo objects matching the criteria.
         """
+
+        if not host:
+            return list(filter(lambda x: x.primary, self.workspaces))
 
         if primary:
             return list(

--- a/client/version_control/launch_hooks/perforce/pre_load_create_workspaces.py
+++ b/client/version_control/launch_hooks/perforce/pre_load_create_workspaces.py
@@ -1,20 +1,10 @@
-import pathlib
-from ayon_applications import (
-    PreLaunchHook,
-    LaunchTypes,
-    ApplicationLaunchFailed
-)
-
-from ayon_core.addon import AddonsManager
-from version_control.api.models import ServerWorkspaces
-from version_control.api.workspaces import list_workspaces
-from version_control.rest.perforce.rest_stub import PerforceRestStub
-from version_control.addon import LoginError, VersionControlAddon
-from ayon_core.lib import get_local_site_id
-from ayon_api import get_base_url
-from version_control.api import perforce
-from version_control.api import workspaces
 import typing
+
+from ayon_applications import LaunchTypes, PreLaunchHook
+from ayon_core.addon import AddonsManager
+from version_control.addon import VersionControlAddon
+from version_control.api import perforce
+from version_control.api.models import ServerWorkspaces
 
 
 class PreLaunchCreateWorkspaces(PreLaunchHook):
@@ -33,7 +23,9 @@ class PreLaunchCreateWorkspaces(PreLaunchHook):
     app_groups = []
     launch_types = {LaunchTypes.local}
 
-    def _get_enabled_version_control_addon(self) -> typing.Union[VersionControlAddon, None]:
+    def _get_enabled_version_control_addon(
+        self,
+    ) -> typing.Union[VersionControlAddon, None]:
         manager = AddonsManager()
         version_control_addon = manager.get("version_control")
         if version_control_addon and version_control_addon.enabled:
@@ -50,5 +42,5 @@ class PreLaunchCreateWorkspaces(PreLaunchHook):
             )
 
             if not perforce.workspace_exists(conn_info):
-                self.log.debug("Workspace %s Does not exist", workspace_name)
+                self.log.debug("Workspace %s Does not exist", workspace.workspace_name)
                 perforce.create_workspace(conn_info)

--- a/client/version_control/launch_hooks/perforce/pre_load_sync_project.py
+++ b/client/version_control/launch_hooks/perforce/pre_load_sync_project.py
@@ -38,13 +38,15 @@ class SyncUnrealProject(PreLaunchHook):
         project_name = self.data["project_name"]
         server_workspaces = ServerWorkspaces(project_name)
 
-        if self.host_name:
-            server_workspaces.get_host_workspaces(self.host_name, True)
+        host_name = self.launch_context.host_name
+        self.log.debug(f"Launch Context Host: {self.launch_context.host_name}")
+        if host_name:
+            server_workspaces.get_host_workspaces(host_name, True)
             if server_workspaces.workspaces:
                 workspace = server_workspaces.workspaces[0]
-                conn_info = perforce.get_connection_info(project_name, workspace.name)
+                conn_info = perforce.get_connection_info(project_name, workspace.name, host_name)
             else:
-                raise ValueError(f"No workspace found for {self.host_name}")
+                raise ValueError(f"No workspace found for {host_name}")
 
             if not perforce.workspace_exists(conn_info):
                 self.log.debug(
@@ -54,7 +56,7 @@ class SyncUnrealProject(PreLaunchHook):
                 perforce.create_workspace(conn_info)
 
             with qt_app_context():
-                changes_tool = ChangesWindows(launch_data=self.data)
+                changes_tool = ChangesWindows(launch_data=self.data, host_name=host_name)
                 changes_tool.show()
                 changes_tool.raise_()
                 changes_tool.activateWindow()

--- a/client/version_control/launch_hooks/perforce/pre_load_sync_project.py
+++ b/client/version_control/launch_hooks/perforce/pre_load_sync_project.py
@@ -10,12 +10,7 @@ Provides:
 
 import os
 
-from ayon_api import get_base_url
-from ayon_applications import (ApplicationLaunchFailed, LaunchTypes,
-                               PreLaunchHook)
-from ayon_core.addon import AddonsManager
-from ayon_core.lib import get_local_site_id
-from ayon_core.pipeline import context_tools
+from ayon_applications import LaunchTypes, PreLaunchHook
 from ayon_core.tools.utils import qt_app_context
 
 from version_control.api import perforce
@@ -92,13 +87,6 @@ class SyncUnrealProject(PreLaunchHook):
                 "Expected only single Unreal project."
             )
         return project_files[0]
-
-    def _get_enabled_version_control_addon(self):
-        manager = AddonsManager()
-        version_control_addon = manager.get("version_control")
-        if version_control_addon and version_control_addon.enabled:
-            return version_control_addon
-        return None
 
     def _find_uproject_files(self, start_dir):
         """

--- a/client/version_control/ui/changes_viewer/__init__.py
+++ b/client/version_control/ui/changes_viewer/__init__.py
@@ -3,12 +3,7 @@ from .window import (
     ChangesWindows,
 )
 
-from .login import (
-    LoginWindow,
-)
-
 __all__ = (
     "show",
     "ChangesWindows",
-    "LoginWindow"
 )

--- a/client/version_control/ui/changes_viewer/window.py
+++ b/client/version_control/ui/changes_viewer/window.py
@@ -17,7 +17,7 @@ module.window = None
 
 
 class ChangesWindows(QtWidgets.QDialog):
-    def __init__(self, controller=None, parent=None, launch_data=None):
+    def __init__(self, controller=None, parent=None, launch_data=None, host_name=None):
         super(ChangesWindows, self).__init__(parent=parent)
         self.setWindowTitle("Changes Viewer")
         self.setObjectName("ChangesViewer")
@@ -27,9 +27,10 @@ class ChangesWindows(QtWidgets.QDialog):
             )
 
         self.resize(780, 430)
+        self._host_name = host_name
 
         if controller is None:
-            controller = ChangesViewerController(launch_data=launch_data)
+            controller = ChangesViewerController(launch_data=launch_data, host=host_name)
 
         self._first_show = True
 


### PR DESCRIPTION
Fixes the triggering of the changes viewer so that it displays the correct workspace for the intended host

![image](https://github.com/user-attachments/assets/bce3bb7c-63df-4d1f-89de-8d21d0c4f8d2)

the changes viewer now is host dependent. Since we've added the feature
to manage multiple workspaces the view needs more context to ensure that
we are syncing the right workspace for the host. 

To use this the host data is passed along from the launch hook using 
the `launch_context` property form the `LaunchHook` object to get information
about the future host, or the host that the user clicked on (I.E unreal, maya)
This was required because when code is activated by the launcher it has no 
host context.


!requires #20 